### PR TITLE
Add go_type_name override in sdk_type_definition

### DIFF
--- a/api/azure/sdk_type_definition.rb
+++ b/api/azure/sdk_type_definition.rb
@@ -46,6 +46,7 @@ module Api
         @empty_value_sensitive = overrides.empty_value_sensitive unless overrides.empty_value_sensitive.nil?
         @go_variable_name = overrides.go_variable_name unless overrides.go_variable_name.nil?
         @go_field_name = overrides.go_field_name unless overrides.go_field_name.nil?
+        @go_type_name = overrides.go_type_name unless overrides.go_type_name.nil?
         @is_pointer_type = overrides.is_pointer_type unless overrides.is_pointer_type.nil?
         @python_parameter_name = overrides.python_parameter_name unless overrides.python_parameter_name.nil?
         @python_variable_name = overrides.python_variable_name unless overrides.python_variable_name.nil?


### PR DESCRIPTION
This PR fix the issue of missing go_type_name override.