### PR TITLE
Fix nested map expanding issue in TestCheckResourceAttr

### DIFF
--- a/provider/azure/terraform/example/helpers.rb
+++ b/provider/azure/terraform/example/helpers.rb
@@ -40,9 +40,9 @@ module Provider
             has_nested_item = false
             properties.each do |pn, pv|
               if pv.is_a?(Hash)
-                flat_properties["#{pn}.#"] = pv.empty? ? 0 : 1
+                 flat_properties["#{pn}.%"] = pv.length if !pn.include?('.')
                 pv.each do |key, val|
-                  flat_properties["#{pn}.0.#{key}"] = val
+                  flat_properties["#{pn}.#{key}"] = val
                   has_nested_item = true if val.is_a?(Hash) || val.is_a?(Array)
                 end
               elsif pv.is_a?(Array)


### PR DESCRIPTION
This PR modifies the map expanding rules in test functions
- Check the number of keys in a single map structure by `.%`.
- Disable the key number checking in nested map structure.
