### PR TITLE
Enable property checking customization in test file

### DIFF
--- a/provider/azure/example/example.rb
+++ b/provider/azure/example/example.rb
@@ -32,6 +32,8 @@ module Provider
       attr_reader :description
       attr_reader :prerequisites
       attr_reader :properties
+      attr_reader :property_check_excludes
+      attr_reader :property_check_includes
 
       def validate
         super
@@ -39,6 +41,8 @@ module Provider
         check :description, type: ::String
         check :prerequisites, type: ::Array, item_type: ExampleReference
         check :properties, type: ::Hash, required: true
+        check :property_check_excludes, type: ::Array, item_type: ::String, required: false
+        check :property_check_includes, type: ::Array, item_type: ::String, required: false
       end
     end
   end


### PR DESCRIPTION
This PR provides supports for customization of property checking in test file. We provide the features of
- Excluding the resource reference property checking automatically.
- Supporting `property_check_includes` field to specify the properties users want to include from all the properties listed in property filed.
- Supporting `property_check_excludes` field to specify the properties users want to exclude.
- When both are specified, we use `property_check_includes` rather than `property_check_excludes`.

The customization rules in the _basic.yaml_ or _complete.yaml_ are
- The two filed are designed to be array of strings.
- Using the terraform state representation to specify the property.
- Using `prop*` to represent all the sub-properties inside the `prop`.

Here is an example.  And this results in checking only all the representations with prefix `custom_rules.1` in test file.
 ```yaml
--- !ruby/object:Provider::Azure::Example
resource: azurerm_web_application_firewall_policy
prerequisites:
  - !ruby/object:Provider::Azure::ExampleReference
    product: resourcegroup
    example: basic
properties:
  name: "<%= get_resource_name('ApplicationGatewayWebApplicationFirewallPolicies', 'wafpolicy') -%>"
  resource_group_name: ${azurerm_resource_group.<%= resource_id_hint -%>.name}
  location: ${azurerm_resource_group.<%= resource_id_hint -%>.location}
  custom_rules:
    - name: Rule1
      priority: 1
      rule_type: MatchRule
      match_conditions:
        - match_variables:
            - variable_name: RemoteAddr
          operator: IPMatch
          negation_conditon: false
          match_values: [192.168.1.0/24, 10.0.0.0/24]
      action: Block
    - name: Rule2
      priority: 2
      rule_type: MatchRule
      match_conditions:
        - match_variables:
            - variable_name: RemoteAddr
          operator: IPMatch
          negation_conditon: false
          match_values: [192.168.1.0/24]
        - match_variables:
            - variable_name: RequestHeaders
              selector: UserAgent
          operator: Contains
          negation_conditon: false
          match_values: [Windows]
      action: Block
property_check_excludes:
  - custom_rules.#
  - custom_rules.0.*
``` 