### PR TITLE
Enhancement for expand/flatten function redeclarations checking

### DIFF
--- a/provider/azure/terraform/sdk/sdk_marshal_descriptor.rb
+++ b/provider/azure/terraform/sdk/sdk_marshal_descriptor.rb
@@ -37,10 +37,12 @@ module Provider
             MarshalDescriptor.new @package, @resource, @queue, sdktype, (properties || @properties)
           end
 
-          def enqueue(property)
+          def enqueue(property, global_queue)
             ef_desc = ExpandFlattenDescriptor.new(property, self)
             exist = @queue.find{|q| q.equals?(ef_desc)}
-            @queue << ef_desc if exist.nil?
+            global_exist = global_queue.find{|q| q.equals?(ef_desc)}
+            @queue << ef_desc if global_exist.nil?
+            global_queue << ef_desc if global_exist.nil?
             (exist || ef_desc).func_name
           end
         end

--- a/templates/azure/terraform/resource.erb
+++ b/templates/azure/terraform/resource.erb
@@ -24,6 +24,8 @@ package azurerm
     azure_client_name = object.azure_sdk_definition.go_client
     sdk_package = object.azure_sdk_definition.go_client_namespace
 
+    $global_expand_queue = Array.new unless defined? $global_expand_queue
+    $global_flatten_queue = Array.new unless defined? $global_flatten_queue
     expand_queue = Array.new
     flatten_queue = Array.new
 

--- a/templates/azure/terraform/schemas/flatten_set.erb
+++ b/templates/azure/terraform/schemas/flatten_set.erb
@@ -1,4 +1,4 @@
-<%  flatten_func_name = sdk_marshal.enqueue(property) -%>
+<%  flatten_func_name = sdk_marshal.enqueue(property, $global_flatten_queue) -%>
 <%  if output_var == 'd' -%>
 if err := d.Set("<%= prop_name -%>", flatten<%= sdk_marshal.resource -%><%= flatten_func_name -%>(<%= input_var -%>)); err != nil {
     return fmt.Errorf("Error setting `<%= prop_name -%>`: %+v", err)

--- a/templates/azure/terraform/sdktypes/datetime_and_duration_field_assign.erb
+++ b/templates/azure/terraform/sdktypes/datetime_and_duration_field_assign.erb
@@ -2,7 +2,7 @@
 <%  if property.is_a?(Api::Azure::Type::ISO8601Duration) -%>
 utils.String(<%= property.name.camelcase(:lower) -%>
 <%  elsif property.is_a?(Api::Azure::Type::ISO8601DateTime) -%>
-<%    sdk_marshal.enqueue(property) -%>
+<%    sdk_marshal.enqueue(property, $global_expand_queue) -%>
 convertStringToDate(<%= property.name.camelcase(:lower) -%>
 <%  end -%>
 )<%= ',' if in_structure -%>

--- a/templates/azure/terraform/sdktypes/expand_func_field_assign.erb
+++ b/templates/azure/terraform/sdktypes/expand_func_field_assign.erb
@@ -9,7 +9,7 @@ utils.ExpandStringSlice(<%= property.name.camelcase(:lower) -%>
 <%  elsif property.is_a?(Api::Type::KeyValuePairs) -%>
 utils.ExpandKeyValuePairs(<%= property.name.camelcase(:lower) -%>
 <%  else -%>
-<%    expand_func_name = sdk_marshal.enqueue(property) -%>
+<%    expand_func_name = sdk_marshal.enqueue(property, $global_expand_queue) -%>
 expand<%= sdk_marshal.resource -%><%= expand_func_name -%>(<%= property.name.camelcase(:lower) -%>
 <%  end -%>
 )<%= ',' if in_structure -%>


### PR DESCRIPTION
This PR updates the checking rules for expand/flatten function redeclarations. Two properties are treated to use a same expand/flatten function as long as

1. They have the same go_type_name
2. Their sub-properties are with the same structure and same go_type_name
