### PR TITLE
Enable enum array for azure_sdk_type_definition

### DIFF
--- a/api/azure/sdk_type_definition.rb
+++ b/api/azure/sdk_type_definition.rb
@@ -87,6 +87,9 @@ module Api
         end
       end
 
+      class EnumArrayObject < EnumObject
+      end
+
       class ISO8601DurationObject < StringObject
       end
 

--- a/provider/azure/terraform/sdk/helpers.rb
+++ b/provider/azure/terraform/sdk/helpers.rb
@@ -46,7 +46,8 @@ module Provider
               'templates/azure/terraform/sdktypes/datetime_and_duration_field_assign.erb'
             when Api::Azure::SDKTypeDefinition::BooleanObject, Api::Azure::SDKTypeDefinition::StringObject,
                  Api::Azure::SDKTypeDefinition::IntegerObject, Api::Azure::SDKTypeDefinition::FloatObject,
-                 Api::Azure::SDKTypeDefinition::StringArrayObject, Api::Azure::SDKTypeDefinition::StringMapObject
+                 Api::Azure::SDKTypeDefinition::StringArrayObject, Api::Azure::SDKTypeDefinition::StringMapObject,
+                 Api::Azure::SDKTypeDefinition::EnumArrayObject
               'templates/azure/terraform/sdktypes/expand_func_field_assign.erb'
             when Api::Azure::SDKTypeDefinition::Integer32Object, Api::Azure::SDKTypeDefinition::Integer64Object
               'templates/azure/terraform/sdktypes/integer_field_assign.erb'

--- a/templates/azure/terraform/expand_property_method.erb
+++ b/templates/azure/terraform/expand_property_method.erb
@@ -121,6 +121,15 @@ func expand<%= sdk_marshal.resource -%><%= descriptor.func_name -%>(input <%= go
   }
   return req, nil
 }
+<%      elsif property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::Enum) -%>
+    results := make([]<%= sdk_marshal.package -%>.<%= sdk_marshal.sdktype.go_type_name -%>, 0)
+    for _, item := range input {
+        v := item.(string)
+        result := <%= sdk_marshal.package -%>.<%= sdk_marshal.sdktype.go_type_name -%>(v)
+        results = append(results, result)
+    }
+    return &results
+}
 <%     else -%>
 <%       if property.is_a?(Api::Type::ResourceRef) -%>
   f, err := <%= build_expand_resource_ref('v.(string)', property) %>

--- a/templates/azure/terraform/flatten_property_method.erb
+++ b/templates/azure/terraform/flatten_property_method.erb
@@ -48,6 +48,18 @@ func flatten<%= sdk_marshal.resource -%><%= descriptor.func_name -%>(input *<%= 
     }
 
     return results
+<% elsif property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::Enum) -%>
+    results := make([]interface{}, 0)
+    if input == nil {
+        return results
+    }
+
+    for _, item := range *input {
+        result := string(item)
+        results = append(results, result)
+    }
+
+    return results
 <% elsif property.is_a?(Api::Type::Map) -%>
     if v == nil {
       return v

--- a/templates/azure/terraform/schemas/primitive.erb
+++ b/templates/azure/terraform/schemas/primitive.erb
@@ -98,6 +98,16 @@
 <%     else # array of basic types -%>
     Elem: &schema.Schema{
         Type: <%= tf_types[property.item_type.class] -%>,
+<%      if property.item_type.is_a?(Api::Type::Enum)
+          enum_values = property.item_type.values
+          sdk_type = get_sdk_typedef_by_references(property.azure_sdk_references, object.azure_sdk_definition.create.request)
+-%>
+        ValidateFunc: validation.StringInSlice([]string{
+<%      enum_values.each do |val| -%>
+            <%= azure_go_literal((sdk_type.go_enum_const_prefix + val.to_s).to_sym, sdk_package) -%>,
+<%      end -%>
+       }, false),
+<%     end -%>
     },
 <%     end -%>
 <%     if property.is_set -%>


### PR DESCRIPTION
This PR provides support for enum array type in azure sdk type definition.
