### PR TITLE
Support new code style for tags in Read operation

### DIFF
--- a/provider/azure/terraform/helpers.rb
+++ b/provider/azure/terraform/helpers.rb
@@ -27,6 +27,14 @@ module Provider
           sorted_other = data_source_input.empty? ? order_properties(other_props) : other_props.sort_by(&:name)
           sorted_special + sorted_other
         end
+
+        def is_tags_defined?(sdk_operation)
+          sdk_operation.response.has_key?('/tags')
+        end
+
+        def go_field_name_of_tags(sdk_operation)
+          sdk_operation.response['/tags'].go_field_name
+        end
       end
     end
   end

--- a/templates/azure/terraform/resource.erb
+++ b/templates/azure/terraform/resource.erb
@@ -183,7 +183,8 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 
 <%= lines(build_sdk_object_to_property('resp', 'd', sdk_marshal)) -%>
 
-    return nil
+    return <%= is_tags_defined?(sdk_operation) ? "tags.FlattenAndSet(d, resp.#{go_field_name_of_tags(sdk_operation)})" : 'nil' -%>
+
 }
 
 <%  if !combine_create_update -%>

--- a/templates/azure/terraform/sdktypes/primitive_schema_assign.erb
+++ b/templates/azure/terraform/sdktypes/primitive_schema_assign.erb
@@ -1,4 +1,6 @@
 <%  input_var = sdk_marshal.sdktype.type_definition.go_variable_name || input + "." + sdk_marshal.sdktype.type_definition.go_field_name -%>
-<%  get_properties_matching_sdk_reference(sdk_marshal.properties, sdk_marshal.sdktype.typedef_reference).each do |property| -%>
-<%=   lines(build_schema_property_set(input_var, output, property, sdk_marshal.clone())) -%>
+<%  get_properties_matching_sdk_reference(sdk_marshal.properties, sdk_marshal.sdktype.typedef_reference).each do |property|
+      if !property.is_a?(Api::Azure::Type::Tags) -%>
+<%=     lines(build_schema_property_set(input_var, output, property, sdk_marshal.clone())) -%>
+<%    end -%>
 <%  end -%>


### PR DESCRIPTION
This PR provides support for Hashcorp's new coding style for Tags in the resource's Read operation.
