### PR TITLE
Fix nil class issue when enum_array is used as output

### DIFF
--- a/templates/azure/terraform/schemas/primitive.erb
+++ b/templates/azure/terraform/schemas/primitive.erb
@@ -98,7 +98,7 @@
 <%     else # array of basic types -%>
     Elem: &schema.Schema{
         Type: <%= tf_types[property.item_type.class] -%>,
-<%      if property.item_type.is_a?(Api::Type::Enum)
+<%      if property.item_type.is_a?(Api::Type::Enum) && property.validation.nil? && !property.output
           enum_values = property.item_type.values
           sdk_type = get_sdk_typedef_by_references(property.azure_sdk_references, object.azure_sdk_definition.create.request)
 -%>


### PR DESCRIPTION
This PR fixes the nil class issue when enum_array is used as output.