### PR TITLE
SDKTypeDefinitionOverride support sublcass with concrete type definition

### DIFF
--- a/api/azure/sdk_type_definition.rb
+++ b/api/azure/sdk_type_definition.rb
@@ -86,6 +86,11 @@ module Api
           check :go_enum_type_name, type: ::String
           check :go_enum_const_prefix, type: ::String, default: ''
         end
+
+        def merge_overrides!(overrides)
+          @go_enum_type_name = overrides.go_enum_type_name unless overrides.go_enum_type_name.nil?
+          @go_enum_const_prefix = overrides.go_enum_const_prefix unless overrides.go_enum_const_prefix.nil?
+        end
       end
 
       class EnumArrayObject < EnumObject

--- a/api/azure/sdk_type_definition.rb
+++ b/api/azure/sdk_type_definition.rb
@@ -88,6 +88,7 @@ module Api
         end
 
         def merge_overrides!(overrides)
+            super
           @go_enum_type_name = overrides.go_enum_type_name unless overrides.go_enum_type_name.nil?
           @go_enum_const_prefix = overrides.go_enum_const_prefix unless overrides.go_enum_const_prefix.nil?
         end

--- a/api/azure/sdk_type_definition.rb
+++ b/api/azure/sdk_type_definition.rb
@@ -88,7 +88,7 @@ module Api
         end
 
         def merge_overrides!(overrides)
-            super
+          super
           @go_enum_type_name = overrides.go_enum_type_name unless overrides.go_enum_type_name.nil?
           @go_enum_const_prefix = overrides.go_enum_const_prefix unless overrides.go_enum_const_prefix.nil?
         end

--- a/api/azure/sdk_type_definition_override.rb
+++ b/api/azure/sdk_type_definition_override.rb
@@ -22,6 +22,62 @@ module Api
         super
         check :remove, type: :boolean, default: false
       end
+
+      class BooleanObjectOverride < SDKTypeDefinitionOverride
+      end
+
+      class IntegerObjectOverride < SDKTypeDefinitionOverride
+      end
+
+      class Integer32ObjectOverride < SDKTypeDefinitionOverride
+      end
+
+      class Integer64ObjectOverride < SDKTypeDefinitionOverride
+      end
+
+      class Integer32ArrayObjectOverride < SDKTypeDefinitionOverride
+      end
+
+      class Integer64ArrayObjectOverride < SDKTypeDefinitionOverride
+      end
+
+      class FloatObjectOverride < SDKTypeDefinitionOverride
+      end
+
+      class StringObjectOverride < SDKTypeDefinitionOverride
+      end
+
+      class EnumObjectOverride < SDKTypeDefinitionOverride
+        attr_reader :go_enum_type_name
+        attr_reader :go_enum_const_prefix
+
+        def validate
+          super
+          check :go_enum_type_name, type: ::String
+          check :go_enum_const_prefix, type: ::String, default: ''
+        end
+      end
+
+      class EnumArrayObjectOverride < EnumObjectOverride
+      end
+
+      class ISO8601DurationObjectOverride < StringObjectOverride
+      end
+
+      class ISO8601DateTimeObjectOverride < SDKTypeDefinitionOverride
+      end
+
+      class ComplexObjectOverride < SDKTypeDefinitionOverride
+      end
+
+      class StringArrayObjectOverride < SDKTypeDefinitionOverride
+      end
+
+      class ComplexArrayObjectOverride < ComplexObjectOverride
+      end
+
+      class StringMapObjectOverride < SDKTypeDefinitionOverride
+      end
     end
   end
 end


### PR DESCRIPTION
Previously all overriden attribute under `request/response` is of
`SDKTypeDefinitionOverride` type.

However, sometimes the overriden
field's type contain some special attribute, which might need the
capability to be overriden, then you will need to export this field
as `attribute` in `SDKTypeDefinitionOverride` (otherwise, you will
end up with errros complaining your override has extraneous instance
variable).

This might work at first, however, when this kind of request increase,
your `SDKTypeDefinitionOverride` will end up to be a mess.

So I choose to inherit `SDKTypeDefinitionOverride` and define concrete
SDK Type's override class (the same way as concrete SDK type against
`SDKTypeDefinition`). Once you need to export some field to be
overridable, you just export them in the concrete type override class.
And furthermore, you need to define the `merge_overrides!` in concrete
type class (not the override class), so that when merging overriden to
overridee class, your exported field will got merged.

This change extend the syntax in `terraform.yaml/ansible.yaml` in way
that you can specify the concrete type for fields under
`request`/`response` (e.g. you will have to specify the type in above
example). On the otherhand, this change should hopefully has no impact
to existing override yamls (so no change is needed for existing ones).

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
