### PR TITLE
Add prop option to compact e/f func name

### DIFF
--- a/provider/azure/terraform/property_override.rb
+++ b/provider/azure/terraform/property_override.rb
@@ -28,6 +28,7 @@ module Provider
             custom_schema_get
             custom_schema_set
             custom_sdkfield_assign
+            compact_ef_func_name
           ])
         end
 
@@ -43,6 +44,7 @@ module Provider
           check :custom_schema_get, type: ::String
           check :custom_schema_set, type: ::String
           check :custom_sdkfield_assign, type: ::String
+          check :compact_ef_func_name, {type: :boolean, default: false}
         end
       end
 

--- a/provider/azure/terraform/property_override.rb
+++ b/provider/azure/terraform/property_override.rb
@@ -28,7 +28,7 @@ module Provider
             custom_schema_get
             custom_schema_set
             custom_sdkfield_assign
-            compact_ef_func_name
+            custom_ef_func_name
           ])
         end
 
@@ -44,7 +44,7 @@ module Provider
           check :custom_schema_get, type: ::String
           check :custom_schema_set, type: ::String
           check :custom_sdkfield_assign, type: ::String
-          check :compact_ef_func_name, {type: :boolean, default: false}
+          check :custom_ef_func_name, type: ::String
         end
       end
 

--- a/provider/azure/terraform_extension.rb
+++ b/provider/azure/terraform_extension.rb
@@ -111,19 +111,6 @@ module Provider
         filepath = File.join(target_folder, "#{name}.html.markdown")
         data.generate('templates/azure/terraform/datasource.html.markdown.erb', filepath, self)
       end
-
-      def build_ef_func_name(resource_name, type_name, compact: false)
-        result = resource_name + type_name
-        # compact resource_name and type_name with potential overlapping
-        if compact
-          (0...type_name.length).each do |idx|
-            if resource_name.end_with? type_name[0..idx]
-              result = resource_name + type_name[idx + 1..-1]
-            end
-          end
-        end
-        result
-      end
     end
   end
 end

--- a/provider/azure/terraform_extension.rb
+++ b/provider/azure/terraform_extension.rb
@@ -112,6 +112,18 @@ module Provider
         data.generate('templates/azure/terraform/datasource.html.markdown.erb', filepath, self)
       end
 
+      def build_ef_func_name(resource_name, type_name, compact: false)
+        result = resource_name + type_name
+        # compact resource_name and type_name with potential overlapping
+        if compact
+          (0...type_name.length).each do |idx|
+            if resource_name.end_with? type_name[0..idx]
+              result = resource_name + type_name[idx + 1..-1]
+            end
+          end
+        end
+        result
+      end
     end
   end
 end

--- a/templates/azure/terraform/expand_property_method.erb
+++ b/templates/azure/terraform/expand_property_method.erb
@@ -23,7 +23,7 @@ func convertStringToDate(input interface{}) *date.Time {
   return &result
 }
 <%    elsif property.is_a?(Api::Type::Map) -%>
-func expand<%= build_ef_func_name(sdk_marshal.resource, titlelize_property(property), compact: property.compact_ef_func_name) -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]interface{}, error) {
+func expand<%= property.custom_ef_func_name.nil? ? sdk_marshal.resource+titlelize_property(property) : property.custom_ef_func_name -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]interface{}, error) {
   if v == nil {
     return map[string]interface{}{}, nil
   }
@@ -34,7 +34,7 @@ func expand<%= build_ef_func_name(sdk_marshal.resource, titlelize_property(prope
 
 <%      property.value_type.nested_properties.each do |prop| -%>
 <%        next if prop.name == property.key_name -%>
-    transformed<%= titlelize_property(prop) -%>, err := expand<%= build_ef_func_name(sdk_marshal.resource, titlelize_property(property), compact: property.compact_ef_func_name) -%><%= titlelize_property(prop) -%>(original["<%= Google::StringUtils.underscore(prop.name) -%>"], d, config)
+    transformed<%= titlelize_property(prop) -%>, err := expand<%= property.custom_ef_func_name.nil? ? sdk_marshal.resource+titlelize_property(property) : property.custom_ef_func_name -%><%= titlelize_property(prop) -%>(original["<%= Google::StringUtils.underscore(prop.name) -%>"], d, config)
     if err != nil {
       return nil, err
     }
@@ -52,7 +52,7 @@ func expand<%= build_ef_func_name(sdk_marshal.resource, titlelize_property(prope
 <%#      lines(build_azure_expand_method(sdk_marshal.resource + titlelize_property(property), prop), 1) -%>
 <%      end -%>
 <%    elsif property.is_a?(Api::Type::KeyValuePairs) -%>
-func expand<%= build_ef_func_name(sdk_marshal.resource, titlelize_property(property), compact: property.compact_ef_func_name) -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]string, error) {
+func expand<%= property.custom_ef_func_name.nil? ? sdk_marshal.resource+titlelize_property(property) : property.custom_ef_func_name -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]string, error) {
   if v == nil {
     return map[string]string{}, nil
   }
@@ -63,7 +63,7 @@ func expand<%= build_ef_func_name(sdk_marshal.resource, titlelize_property(prope
   return m, nil
 }
 <%    elsif tf_types.include?(property.class) -%>
-func expand<%= build_ef_func_name(sdk_marshal.resource, descriptor.func_name, compact: property.compact_ef_func_name) -%>(input <%= go_type(property) -%>) *<%= '[]' if property.is_a?(Api::Type::Array) -%><%= sdk_marshal.package -%>.<%= sdk_marshal.sdktype.go_type_name -%> {
+func expand<%= property.custom_ef_func_name.nil? ? sdk_marshal.resource+descriptor.func_name : property.custom_ef_func_name -%>(input <%= go_type(property) -%>) *<%= '[]' if property.is_a?(Api::Type::Array) -%><%= sdk_marshal.package -%>.<%= sdk_marshal.sdktype.go_type_name -%> {
 <%
         if !property.nested_properties.empty?
           nested_properties = property.nested_properties

--- a/templates/azure/terraform/expand_property_method.erb
+++ b/templates/azure/terraform/expand_property_method.erb
@@ -23,7 +23,7 @@ func convertStringToDate(input interface{}) *date.Time {
   return &result
 }
 <%    elsif property.is_a?(Api::Type::Map) -%>
-func expand<%= sdk_marshal.resource -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]interface{}, error) {
+func expand<%= build_ef_func_name(sdk_marshal.resource, titlelize_property(property), compact: property.compact_ef_func_name) -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]interface{}, error) {
   if v == nil {
     return map[string]interface{}{}, nil
   }
@@ -52,7 +52,7 @@ func expand<%= sdk_marshal.resource -%><%= titlelize_property(property) -%>(v in
 <%#      lines(build_azure_expand_method(sdk_marshal.resource + titlelize_property(property), prop), 1) -%>
 <%      end -%>
 <%    elsif property.is_a?(Api::Type::KeyValuePairs) -%>
-func expand<%= sdk_marshal.resource -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]string, error) {
+func expand<%= build_ef_func_name(sdk_marshal.resource, titlelize_property(property), compact: property.compact_ef_func_name) -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]string, error) {
   if v == nil {
     return map[string]string{}, nil
   }
@@ -63,7 +63,7 @@ func expand<%= sdk_marshal.resource -%><%= titlelize_property(property) -%>(v in
   return m, nil
 }
 <%    elsif tf_types.include?(property.class) -%>
-func expand<%= sdk_marshal.resource -%><%= descriptor.func_name -%>(input <%= go_type(property) -%>) *<%= '[]' if property.is_a?(Api::Type::Array) -%><%= sdk_marshal.package -%>.<%= sdk_marshal.sdktype.go_type_name -%> {
+func expand<%= build_ef_func_name(sdk_marshal.resource, descriptor.func_name, compact: property.compact_ef_func_name) -%>(input <%= go_type(property) -%>) *<%= '[]' if property.is_a?(Api::Type::Array) -%><%= sdk_marshal.package -%>.<%= sdk_marshal.sdktype.go_type_name -%> {
 <%
         if !property.nested_properties.empty?
           nested_properties = property.nested_properties

--- a/templates/azure/terraform/expand_property_method.erb
+++ b/templates/azure/terraform/expand_property_method.erb
@@ -34,7 +34,7 @@ func expand<%= build_ef_func_name(sdk_marshal.resource, titlelize_property(prope
 
 <%      property.value_type.nested_properties.each do |prop| -%>
 <%        next if prop.name == property.key_name -%>
-    transformed<%= titlelize_property(prop) -%>, err := expand<%= sdk_marshal.resource -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= Google::StringUtils.underscore(prop.name) -%>"], d, config)
+    transformed<%= titlelize_property(prop) -%>, err := expand<%= build_ef_func_name(sdk_marshal.resource, titlelize_property(property), compact: property.compact_ef_func_name) -%><%= titlelize_property(prop) -%>(original["<%= Google::StringUtils.underscore(prop.name) -%>"], d, config)
     if err != nil {
       return nil, err
     }

--- a/templates/azure/terraform/flatten_property_method.erb
+++ b/templates/azure/terraform/flatten_property_method.erb
@@ -71,7 +71,7 @@ func flatten<%= build_ef_func_name(sdk_marshal.resource, descriptor.func_name, c
     transformed = append(transformed, map[string]interface{}{
       "<%= property.key_name -%>": k,
     <% property.value_type.properties.each do |prop| -%>
-      "<%= Google::StringUtils.underscore(prop.name) -%>": flatten<%= sdk_marshal.resource -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= prop.api_name -%>"]),
+      "<%= Google::StringUtils.underscore(prop.name) -%>": flatten<%= build_ef_func_name(sdk_marshal.resource, titlelize_property(property), compact: property.compact_ef_func_name) -%><%= titlelize_property(prop) -%>(original["<%= prop.api_name -%>"]),
     <% end -%>
     })
   }

--- a/templates/azure/terraform/flatten_property_method.erb
+++ b/templates/azure/terraform/flatten_property_method.erb
@@ -22,7 +22,7 @@
                            property: property)) -%>
 <% else -%>
 <% if tf_types.include?(property.class) -%>
-func flatten<%= sdk_marshal.resource -%><%= descriptor.func_name -%>(input *<%= '[]' if property.is_a?(Api::Type::Array) -%><%= sdk_marshal.package -%>.<%= sdk_marshal.sdktype.go_type_name -%>) []interface{} {
+func flatten<%= build_ef_func_name(sdk_marshal.resource, descriptor.func_name, compact: property.compact_ef_func_name) -%>(input *<%= '[]' if property.is_a?(Api::Type::Array) -%><%= sdk_marshal.package -%>.<%= sdk_marshal.sdktype.go_type_name -%>) []interface{} {
 <% if property.is_a?(Api::Type::NestedObject) -%>
     if input == nil {
         return make([]interface{}, 0)

--- a/templates/azure/terraform/flatten_property_method.erb
+++ b/templates/azure/terraform/flatten_property_method.erb
@@ -22,7 +22,7 @@
                            property: property)) -%>
 <% else -%>
 <% if tf_types.include?(property.class) -%>
-func flatten<%= build_ef_func_name(sdk_marshal.resource, descriptor.func_name, compact: property.compact_ef_func_name) -%>(input *<%= '[]' if property.is_a?(Api::Type::Array) -%><%= sdk_marshal.package -%>.<%= sdk_marshal.sdktype.go_type_name -%>) []interface{} {
+func flatten<%= property.custom_ef_func_name.nil? ? sdk_marshal.resource+descriptor.func_name : property.custom_ef_func_name -%>(input *<%= '[]' if property.is_a?(Api::Type::Array) -%><%= sdk_marshal.package -%>.<%= sdk_marshal.sdktype.go_type_name -%>) []interface{} {
 <% if property.is_a?(Api::Type::NestedObject) -%>
     if input == nil {
         return make([]interface{}, 0)
@@ -71,7 +71,7 @@ func flatten<%= build_ef_func_name(sdk_marshal.resource, descriptor.func_name, c
     transformed = append(transformed, map[string]interface{}{
       "<%= property.key_name -%>": k,
     <% property.value_type.properties.each do |prop| -%>
-      "<%= Google::StringUtils.underscore(prop.name) -%>": flatten<%= build_ef_func_name(sdk_marshal.resource, titlelize_property(property), compact: property.compact_ef_func_name) -%><%= titlelize_property(prop) -%>(original["<%= prop.api_name -%>"]),
+      "<%= Google::StringUtils.underscore(prop.name) -%>": flatten<%= property.custom_ef_func_name.nil? ? sdk_marshal.resource+titlelize_property(property) : property.custom_ef_func_name -%><%= titlelize_property(prop) -%>(original["<%= prop.api_name -%>"]),
     <% end -%>
     })
   }

--- a/templates/azure/terraform/schemas/flatten_set.erb
+++ b/templates/azure/terraform/schemas/flatten_set.erb
@@ -1,8 +1,8 @@
 <%  flatten_func_name = sdk_marshal.enqueue(property, $global_flatten_queue) -%>
 <%  if output_var == 'd' -%>
-if err := d.Set("<%= prop_name -%>", flatten<%= sdk_marshal.resource -%><%= flatten_func_name -%>(<%= input_var -%>)); err != nil {
+if err := d.Set("<%= prop_name -%>", flatten<%= build_ef_func_name(sdk_marshal.resource, flatten_func_name, compact: property.compact_ef_func_name) -%>(<%= input_var -%>)); err != nil {
     return fmt.Errorf("Error setting `<%= prop_name -%>`: %+v", err)
 }
 <%  else -%>
-<%= output_var -%>["<%= prop_name -%>"] = flatten<%= sdk_marshal.resource -%><%= flatten_func_name -%>(<%= input_var -%>)
+<%= output_var -%>["<%= prop_name -%>"] = flatten<%= build_ef_func_name(sdk_marshal.resource, flatten_func_name, compact: property.compact_ef_func_name) -%>(<%= input_var -%>)
 <%  end -%>

--- a/templates/azure/terraform/schemas/flatten_set.erb
+++ b/templates/azure/terraform/schemas/flatten_set.erb
@@ -1,8 +1,8 @@
 <%  flatten_func_name = sdk_marshal.enqueue(property, $global_flatten_queue) -%>
 <%  if output_var == 'd' -%>
-if err := d.Set("<%= prop_name -%>", flatten<%= build_ef_func_name(sdk_marshal.resource, flatten_func_name, compact: property.compact_ef_func_name) -%>(<%= input_var -%>)); err != nil {
+if err := d.Set("<%= prop_name -%>", flatten<%= property.custom_ef_func_name.nil? ? sdk_marshal.resource+flatten_func_name : property.custom_ef_func_name -%>(<%= input_var -%>)); err != nil {
     return fmt.Errorf("Error setting `<%= prop_name -%>`: %+v", err)
 }
 <%  else -%>
-<%= output_var -%>["<%= prop_name -%>"] = flatten<%= build_ef_func_name(sdk_marshal.resource, flatten_func_name, compact: property.compact_ef_func_name) -%>(<%= input_var -%>)
+<%= output_var -%>["<%= prop_name -%>"] = flatten<%= property.custom_ef_func_name.nil? ? sdk_marshal.resource+flatten_func_name : property.custom_ef_func_name -%>(<%= input_var -%>)
 <%  end -%>

--- a/templates/azure/terraform/sdktypes/expand_func_field_assign.erb
+++ b/templates/azure/terraform/sdktypes/expand_func_field_assign.erb
@@ -10,6 +10,6 @@ utils.ExpandStringSlice(<%= property.name.camelcase(:lower) -%>
 utils.ExpandKeyValuePairs(<%= property.name.camelcase(:lower) -%>
 <%  else -%>
 <%    expand_func_name = sdk_marshal.enqueue(property, $global_expand_queue) -%>
-expand<%= sdk_marshal.resource -%><%= expand_func_name -%>(<%= property.name.camelcase(:lower) -%>
+expand<%= build_ef_func_name(sdk_marshal.resource, expand_func_name, compact: property.compact_ef_func_name) -%>(<%= property.name.camelcase(:lower) -%>
 <%  end -%>
 )<%= ',' if in_structure -%>

--- a/templates/azure/terraform/sdktypes/expand_func_field_assign.erb
+++ b/templates/azure/terraform/sdktypes/expand_func_field_assign.erb
@@ -10,6 +10,6 @@ utils.ExpandStringSlice(<%= property.name.camelcase(:lower) -%>
 utils.ExpandKeyValuePairs(<%= property.name.camelcase(:lower) -%>
 <%  else -%>
 <%    expand_func_name = sdk_marshal.enqueue(property, $global_expand_queue) -%>
-expand<%= build_ef_func_name(sdk_marshal.resource, expand_func_name, compact: property.compact_ef_func_name) -%>(<%= property.name.camelcase(:lower) -%>
+expand<%= property.custom_ef_func_name.nil? ? sdk_marshal.resource+expand_func_name : property.custom_ef_func_name -%>(<%= property.name.camelcase(:lower) -%>
 <%  end -%>
 )<%= ',' if in_structure -%>


### PR DESCRIPTION
Introduce a new property option: `compact_ef_func_name` to compact
expand/flatten function name.

E/F func name is constrcuted as: `resource_name` + `go_sdk_type_name`.
In some cases the `go_sdk_type_name` might use `resource_name` as
prefix, which in most case is redundent (cause without which, there is
no name conflict inside that go package). So as to make tf reviewer
happy, we can turn that option on.

This fixes issue: #60
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
