### PR TITLE
Fix bug after opting specific override typing

### DIFF
--- a/api/azure/sdk_type_definition.rb
+++ b/api/azure/sdk_type_definition.rb
@@ -92,6 +92,11 @@ module Api
 
         def merge_overrides!(overrides)
           super
+          # `overrides` is instance of either SDKTypeDefinitionOverride or
+          # SDKTypeDefinitionOverride::EnumObjectOverride. We only merge type specific
+          # attribute for the latter case.
+          return unless overrides.instance_of? Api::Azure::SDKTypeDefinitionOverride::EnumObjectOverride
+
           @go_enum_type_name = overrides.go_enum_type_name unless overrides.go_enum_type_name.nil?
           @go_enum_const_prefix = overrides.go_enum_const_prefix unless overrides.go_enum_const_prefix.nil?
         end


### PR DESCRIPTION
If the override sdk type def is not type specific, then we should not
tackle with the type specific part in merge method.

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
