### PR TITLE
Enable yaml alias in YAML.safe_load

### DIFF
--- a/google/yaml_validator.rb
+++ b/google/yaml_validator.rb
@@ -24,7 +24,7 @@ module Google
         # TODO(nelsonjr): Allow specifying which symbols to restrict it further.
         # But it requires inspecting all configuration files for symbol sources,
         # such as Enum values. Leaving it as a nice-to-have for the future.
-        YAML.safe_load(content, allowed_classes)
+        YAML.safe_load(content, allowed_classes, aliases: true)
       end
 
       def allowed_classes


### PR DESCRIPTION
Yaml anchor, alias is helpful to DRY. E.g. for batchaccount api.yaml,
we can anchor sdk def for `resourceGroup` and `accountName` and alias
that at CRUD request.
For the alias's name, magic module already support private field to skip
yaml validation, in other word, magic module already has some mechanism
to work around extraneous field checking. We can use that mechanism to
name our aliases, starts with '__'.

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
