### PR TITLE
Filter out `location` from updatable_properties

### DIFF
--- a/templates/azure/terraform/resource.erb
+++ b/templates/azure/terraform/resource.erb
@@ -12,6 +12,7 @@ package azurerm
     settable_properties = properties.reject{ |v| v.output && !v.is_a?(Api::Type::Fingerprint) }.reject(&:url_param_only)
     # PUT needs parameters like `name` to be set in the resource body, but we don't want to send them in PATCH
     updatable_properties = settable_properties.reject{|p| !object.azure_sdk_definition.update.nil? && get_applicable_reference(p.azure_sdk_references, object.azure_sdk_definition.update.request).nil?}
+                                              .reject { |p| p.name == "location" } # location is always force new in terraform
     output_properties = properties.reject{|p| p.name == 'id'}
     # Handwritten TF Operation objects will be shaped like accessContextManager while the Google Go Client will have a name like accesscontextmanager
     api_name_lower = String.new(product_ns)
@@ -194,12 +195,10 @@ func resource<%= resource_name -%><%= update_func_name_postfix -%>(d *schema.Res
     ctx := meta.(*ArmClient).StopContext
 
 <%  updatable_properties.sort_by{|p| [p.order, p.name]}.each do |prop| -%>
-<%    if prop.name != "location" -%>
-<%      var_name = get_sdk_typedef_by_references(prop.azure_sdk_references, sdk_operation.request).go_variable_name -%>
-<%      special_known_name = (prop.name == 'tags' ? 't' : nil) -%>
-<%      output_var = var_name || special_known_name || prop.name.camelcase(:lower) -%>
-<%=     lines(build_schema_property_get('d', output_var, prop, sdk_marshal, 4)) -%>
-<%    end -%>
+<%    var_name = get_sdk_typedef_by_references(prop.azure_sdk_references, sdk_operation.request).go_variable_name -%>
+<%    special_known_name = (prop.name == 'tags' ? 't' : nil) -%>
+<%    output_var = var_name || special_known_name || prop.name.camelcase(:lower) -%>
+<%=   lines(build_schema_property_get('d', output_var, prop, sdk_marshal, 4)) -%>
 <%  end -%>
 
     <%= sdk_operation.request['/'].go_variable_name -%> := <%= sdk_package -%>.<%= sdk_operation.request['/'].go_type_name -%>{


### PR DESCRIPTION
Since `location` is always set to be force new, so we should skip it
in update function. Previously if sdk defined `location` as one of
update request fields, the generated code will end up with using an
undefined variable of location during sdk to property part in update
function.

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
