### PR TITLE
don't set Default for output-only property

### DIFF
--- a/templates/azure/terraform/schemas/primitive.erb
+++ b/templates/azure/terraform/schemas/primitive.erb
@@ -143,7 +143,7 @@
 <%   if property.sensitive -%>
     Sensitive: true,
 <%   end -%>
-<%   unless property.default_value.nil? || !data_source_input.empty? -%>
+<%   unless property.output || property.default_value.nil? || !data_source_input.empty? -%>
 <%     if property.is_a?(Api::Type::Enum) -%>
     Default: <%= azure_go_literal((sdk_type.go_enum_const_prefix + property.default_value.to_s).to_sym, sdk_package) -%>,
 <%     elsif property.is_a?(Api::Azure::Type::BooleanEnum) -%>


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

Don't set Default for output-only property