### PR TITLE
remove `sidebar_current` from gen doc

### DIFF
--- a/templates/azure/terraform/datasource.html.markdown.erb
+++ b/templates/azure/terraform/datasource.html.markdown.erb
@@ -12,7 +12,6 @@
 subcategory: ""
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_<%= resource_name -%>"
-sidebar_current: "docs-azurerm-datasource-<%= resource_name.gsub("_", "-") -%>"
 description: |-
   Gets information about an existing <%= lines(object.name.titlecase) -%>
 ---

--- a/templates/azure/terraform/resource.html.markdown.erb
+++ b/templates/azure/terraform/resource.html.markdown.erb
@@ -30,7 +30,6 @@
 subcategory: ""
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_<%= resource_name -%>"
-sidebar_current: "docs-azurerm-resource-<%= resource_name.gsub("_", "-") -%>"
 description: |-
 <%= indent(object.description.first_sentence, 2) %>
 ---


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
remove `sidebar_current` from gen doc