### PR TITLE
Support custom parseID function

### DIFF
--- a/provider/azure/terraform/acctest/sub_template.rb
+++ b/provider/azure/terraform/acctest/sub_template.rb
@@ -17,11 +17,12 @@ module Provider
       module AccTest
         module SubTemplate
 
-          def build_acctest_parameters_from_schema(sdk_op_def, properties, indentation = 8)
+          def build_acctest_parameters_from_schema(sdk_op_def, properties, object, indentation = 8)
             compile_template 'templates/azure/terraform/acctest/parameters_from_schema.erb',
                              indentation: indentation,
                              sdk_op_def: sdk_op_def,
-                             properties: properties
+                             properties: properties,
+                             object: object,
           end
 
         end

--- a/templates/azure/terraform/acctest/parameters_from_schema.erb
+++ b/templates/azure/terraform/acctest/parameters_from_schema.erb
@@ -1,4 +1,8 @@
+id, err := parse.<%= object.name -%>ID(rs.Primary.ID)
+if err != nil {
+    return err
+}
 <%  properties.reject{|p| get_applicable_reference(p.azure_sdk_references, sdk_op_def.request).nil?}.sort_by{|p| [p.order, p.name]}.each do |prop| -%>
 <%    var_name = get_sdk_typedef_by_references(prop.azure_sdk_references, sdk_op_def.request).go_variable_name -%>
-<%=   var_name -%> := rs.Primary.Attributes["<%= prop.name.underscore -%>"]
+<%=   var_name -%> := id.<%= var_name.capitalize -%>
 <%  end -%>

--- a/templates/azure/terraform/resource.erb
+++ b/templates/azure/terraform/resource.erb
@@ -34,6 +34,8 @@ package <%= provider_name.downcase -%>
     update_func_name_postfix = (combine_create_update ? "CreateUpdate" : "Update")
 -%>
 
+import azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+
 func resource<%= resource_name -%>() *schema.Resource {
     return &schema.Resource{
         Create: resource<%= resource_name -%><%= create_func_name_postfix -%>,
@@ -52,9 +54,10 @@ func resource<%= resource_name -%>() *schema.Resource {
         ),
 <%      end -%>
 
-        Importer: &schema.ResourceImporter{
-            State: schema.ImportStatePassthrough,
-        },
+        Importer: &azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+            _, err := parse.<%= object.name -%>ID(id)
+            return err
+        })
 
         Timeouts: &schema.ResourceTimeout{
             Create: schema.DefaultTimeout(30 * time.Minute),

--- a/templates/azure/terraform/sdk/azure_id_parser.erb
+++ b/templates/azure/terraform/sdk/azure_id_parser.erb
@@ -1,8 +1,8 @@
-id, err := azure.ParseAzureResourceID(d.Id())
+id, err := parse.<%=  object.name -%>ID(d.Id())
 if err != nil {
     return err
 }
 <%  sdk_op_def.request.reject {|k, v| v.id_portion.nil?}.each_value do |param| -%>
-<%=   param.go_variable_name -%> := id.<%= param.id_portion == "resourceGroups" ? "ResourceGroup" : "Path[\"#{param.id_portion}\"]" -%>
+<%=   param.go_variable_name -%> := id.<%= param.go_variable_name.capitalize-%>
 
 <%  end -%>

--- a/templates/azure/terraform/test_file.go.erb
+++ b/templates/azure/terraform/test_file.go.erb
@@ -67,7 +67,7 @@ func testCheck<%= resource_name -%>Exists(resourceName string) resource.TestChec
             return fmt.Errorf("<%= object.name.titlecase -%> not found: %s", resourceName)
         }
 
-<%= lines(build_acctest_parameters_from_schema(object.azure_sdk_definition.read, properties)) -%>
+<%= lines(build_acctest_parameters_from_schema(object.azure_sdk_definition.read, properties, object)) -%>
 
         client := acceptance.AzureProvider.Meta().(*clients.Client).<%= provider_name -%>.<%= provider_client_name -%>
 
@@ -95,7 +95,7 @@ func testCheck<%= resource_name -%>Destroy(s *terraform.State) error {
             continue
         }
 
-<%= lines(build_acctest_parameters_from_schema(object.azure_sdk_definition.read, properties)) -%>
+<%= lines(build_acctest_parameters_from_schema(object.azure_sdk_definition.read, properties, object)) -%>
 
         if resp, err := <%= build_sdk_func_invocation(object.azure_sdk_definition.read) -%>; err != nil {
             if !utils.ResponseWasNotFound(resp.Response) {


### PR DESCRIPTION
Terraform azure provider currently introduce custom parseID function,
which is to replace previous `azure.ParseAzureResourceID()`.

Furthermore, this is used at `Importer` to validate importing ID and
in acctest.

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
